### PR TITLE
fix: 댓글 조회, feat: 대댓글 마들기,feat: 내 댓글에 달리 대댓글 가져오기

### DIFF
--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/controller/CommentController.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/controller/CommentController.java
@@ -39,4 +39,19 @@ public class CommentController {
         return commentService.toggleCommentLike(commentId, userDetails.getEmail());
     }//댓글 좋아요
 
+    @PostMapping("/reply/{commentId}")
+    public ResponseEntity<?> createReplyToComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentDto commentDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return commentService.createReplyToComment(commentDto, userDetails.getEmail(),commentId);
+    } //특정 댓글에 reply달기
+
+
+    @GetMapping("/myalarm")
+    public ResponseEntity<?> commentAlarm(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return commentService.commentAlarm(userDetails.getEmail());
+    }//내 댓글에 달린 댓글
+
 }

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
@@ -3,6 +3,7 @@ package com.draconist.goodluckynews.domain.goodNews.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -16,4 +17,5 @@ public class CommentDto {
     private String content;  // 댓글 내용
     private LocalDateTime createdAt; // 작성 날짜
     private int likeCount;   // 댓글 좋아요 개수 추가
+    private List<CommentDto> replies; // 답글 리스트 추가
 }

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Comment.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Comment.java
@@ -32,4 +32,8 @@ public class Comment {
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt; // 댓글 작성 시간
+
+    @ManyToOne
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
 }

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/repository/CommentRepository.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/repository/CommentRepository.java
@@ -14,5 +14,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     int countByPostId(Long id);//댓글 수
     void deleteByPostId(Long postId); // 희소식 삭제 연관
     void deleteById(Long commentId);// 댓글 삭제
+    List<Comment> findByParentCommentId(Long parentCommentId);// 부모 댓글 ID를 통해 답글 목록 조회
+    List<Comment> findByParentCommentUserId(Long parentUserId);  // 부모 댓글이 특정 사용자의 댓글인 대댓글 조회
 }
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -98,20 +99,40 @@ public class CommentService {
         // 1. 모든 댓글 조회
         List<Comment> comments = commentRepository.findAll();
 
-        // 2. 조회된 댓글을 DTO로 변환하여 리스트로 반환
+        // 2. 각 댓글에 대한 답글 조회
         List<CommentDto> commentDtoList = comments.stream()
-                .map(comment -> CommentDto.builder()
-                        .commentId(comment.getId())
-                        .postId(comment.getPostId())
-                        .userId(comment.getUserId())
-                        .content(comment.getContent())
-                        .createdAt(comment.getCreatedAt())
-                        .likeCount(commentLikeRepository.countByCommentId(comment.getId())) // 좋아요 개수 추가
-                        .build())
+                .map(comment -> {
+                    // 댓글에 달린 답글 조회
+                    List<Comment> replies = commentRepository.findByParentCommentId(comment.getId());
+
+                    // 답글 리스트를 CommentDto로 변환
+                    List<CommentDto> replyDtoList = replies.stream()
+                            .map(reply -> CommentDto.builder()
+                                    .commentId(reply.getId())
+                                    .postId(reply.getPostId())
+                                    .userId(reply.getUserId())
+                                    .content(reply.getContent())
+                                    .createdAt(reply.getCreatedAt())
+                                    .likeCount(commentLikeRepository.countByCommentId(reply.getId())) // 좋아요 개수
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    // 댓글을 CommentDto로 변환 후, 답글 리스트 포함
+                    return CommentDto.builder()
+                            .commentId(comment.getId())
+                            .postId(comment.getPostId())
+                            .userId(comment.getUserId())
+                            .content(comment.getContent())
+                            .createdAt(comment.getCreatedAt())
+                            .likeCount(commentLikeRepository.countByCommentId(comment.getId())) // 좋아요 개수
+                            .replies(replyDtoList) // 답글 포함
+                            .build();
+                })
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(commentDtoList);
     }
+
 
     public ResponseEntity<?> toggleCommentLike(Long commentId, String email) {
         // 1. 사용자 조회
@@ -167,5 +188,65 @@ public class CommentService {
                 "댓글이 성공적으로 삭제되었습니다."
         ));
     }//댓글 삭제
+
+    public ResponseEntity<?> createReplyToComment(CommentDto commentDto, String email, Long commentId) {
+        try {
+            // 1. 사용자 정보 조회
+            Member user = memberRepository.findMemberByEmail(email)
+                    .orElseThrow(() -> new RuntimeException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
+
+            // 2. 댓글 조회 (답글을 달기 위한 부모 댓글)
+            Comment parentComment = commentRepository.findById(commentId)
+                    .orElseThrow(() -> new RuntimeException(ErrorStatus.COMMENT_NOT_FOUND.getMessage()));
+
+            // 3. 답글 생성
+            Comment replyComment = Comment.builder()
+                    .postId(parentComment.getPostId())  // 부모 댓글과 동일한 게시글에 답글 추가
+                    .userId(user.getId())
+                    .content(commentDto.getContent())
+                    .parentComment(parentComment)  // 부모 댓글 설정
+                    .build();
+
+            // 4. 댓글 저장
+            commentRepository.save(replyComment);
+
+            return ResponseEntity.status(SuccessStatus.COMMENT_CREATED.getHttpStatus()).body(SuccessStatus.COMMENT_CREATED);
+        } catch (Exception e) {
+            return ResponseEntity.status(ErrorStatus.COMMENT_CREATION_FAILED.getHttpStatus())
+                    .body(ErrorStatus.COMMENT_CREATION_FAILED);
+        }
+    }//댓글에 대한 답글 작성하기
+
+    public ResponseEntity<?> commentAlarm(String email) {
+        // 1. 사용자 정보 조회
+        Member user = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 2. 사용자가 작성한 댓글을 조회
+        List<Comment> userComments = commentRepository.findByUserId(user.getId());
+
+        // 3. 사용자가 작성한 댓글에 달린 대댓글들을 찾기 위한 리스트
+        List<Comment> repliesToUserComments = new ArrayList<>();
+
+        // 4. 사용자가 작성한 댓글에 대해 대댓글이 달린 것들만 찾기
+        for (Comment comment : userComments) {
+            List<Comment> replies = commentRepository.findByParentCommentUserId(comment.getUserId());
+            repliesToUserComments.addAll(replies);
+        }
+
+        // 5. 대댓글이 존재할 경우 처리
+        if (!repliesToUserComments.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.onSuccess(
+                    SuccessStatus.COMMENT_REPLIES_FOUND.getMessage(),
+                    repliesToUserComments
+            ));
+        }
+
+        // 6. 대댓글이 없으면 메시지 반환
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                SuccessStatus.NO_REPLIES_FOUND.getMessage(),
+                "사용자가 작성한 댓글에 달린 대댓글이 없습니다."
+        ));
+    } //내 댓글에 달린 대댓글 찾기
 
 }

--- a/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/SuccessStatus.java
+++ b/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/SuccessStatus.java
@@ -43,7 +43,9 @@ public enum SuccessStatus implements BaseCode {
 	COMMENT_UPDATED(HttpStatus.OK, "COMMENT203", "댓글이 성공적으로 수정되었습니다."),
 	COMMENT_LIKE_SUCCESS(HttpStatus.OK, "COMMENT204", "댓글 좋아요 처리가 완료되었습니다."),
 	COMMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT205", "댓글 목록이 성공적으로 조회되었습니다."),
-	COMMENT_DETAIL_SUCCESS(HttpStatus.OK, "COMMENT206", "댓글 상세 정보가 성공적으로 조회되었습니다.");
+	COMMENT_DETAIL_SUCCESS(HttpStatus.OK, "COMMENT206", "댓글 상세 정보가 성공적으로 조회되었습니다."),
+	COMMENT_REPLIES_FOUND(HttpStatus.OK, "COMMENT207", "대댓글 목록을 성공적으로 가져왔습니다."),
+	NO_REPLIES_FOUND(HttpStatus.OK, "COMMENT208", "해당 댓글에 달린 댓글이 없습니다" );
 
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #53

## 📝작업 내용

댓글에 대댓글을 따로 관리해주어야 해서 대댓글 다는 api만들었고 entity수정했습니다.
    @ManyToOne
    @JoinColumn(name = "parent_comment_id")
    private Comment parentComment;
이렇게 연결했고ㅡ 내 댓글에 달린 대댓글을 get하는 controller도 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
