### PR TITLE
refactor : 작성자, 프로필 이미지 로직 추가

### DIFF
--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
@@ -1,5 +1,6 @@
 package com.draconist.goodluckynews.domain.goodNews.dto;
 
+import com.draconist.goodluckynews.domain.member.dto.WriterInfoDto;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ public class CommentDto {
         private LocalDateTime createdAt; // 작성 날짜
         private int likeCount;   // 댓글 좋아요 개수 추가
         private List<CommentResultDto> replies;// 답글 리스트 추가
+        private WriterInfoDto writer; // 작성자 정보 추가하기
 
     }
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
@@ -1,6 +1,7 @@
 package com.draconist.goodluckynews.domain.goodNews.dto;
 
 import com.draconist.goodluckynews.domain.goodNews.entity.Post;
+import com.draconist.goodluckynews.domain.member.dto.WriterInfoDto;
 import com.draconist.goodluckynews.domain.place.entity.Place;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
@@ -33,8 +34,9 @@ public class GoodnewsDto {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private String placeName;
+        private WriterInfoDto writer; //작성자 정보 추가
 
-        public static GoodnewsResponseDto from(Post post) {
+        public static GoodnewsResponseDto from(Post post, WriterInfoDto writer) {
             return GoodnewsResponseDto.builder()
                     .postId(post.getId())
                     .placeId(post.getPlaceId())
@@ -44,6 +46,7 @@ public class GoodnewsDto {
                     .createdAt(post.getCreatedAt())
                     .updatedAt(post.getUpdatedAt())
                     .placeName(post.getPlace() != null ? post.getPlace().getPlaceName() : null)
+                    .writer(writer) // 작성자 정보 세팅
                     .build();
         }
     }
@@ -64,6 +67,8 @@ public class GoodnewsDto {
         private LocalDateTime updatedAt; // 수정 날짜
         private int likeCount;     // 좋아요 개수 추가
         private int commentCount;  // 댓글 개수 추가
+        private WriterInfoDto writer;// 작성자 정보 필드 추가
+
     }//값 반환 dto
 
     @Builder

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/PostService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/PostService.java
@@ -6,6 +6,7 @@ import com.draconist.goodluckynews.domain.goodNews.entity.PostLike;
 import com.draconist.goodluckynews.domain.goodNews.repository.CommentRepository;
 import com.draconist.goodluckynews.domain.goodNews.repository.PostRepository;
 import com.draconist.goodluckynews.domain.goodNews.repository.PostLikeRepository;
+import com.draconist.goodluckynews.domain.member.dto.WriterInfoDto;
 import com.draconist.goodluckynews.domain.member.entity.Member;
 import com.draconist.goodluckynews.domain.member.repository.MemberRepository;
 import com.draconist.goodluckynews.domain.place.entity.Place;
@@ -38,6 +39,20 @@ public class PostService {
     private final AwsS3Service awsS3Service;
     private final PlaceRepository placeRepository;
 
+
+
+    //공통 작성자 DTO 생성 메서드
+    private WriterInfoDto mapToWriterDto(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        return WriterInfoDto.builder()
+                .userId(member.getId())
+                .name(member.getName())
+                .profileImage(member.getProfileImage())
+                .build();
+    }
+
+
     public ResponseEntity<?> createPost(GoodnewsDto.GoodnewsCreateDto goodnewsCreateDTO, MultipartFile image, String email) {
         try {
             Member user = memberRepository.findMemberByEmail(email)
@@ -63,7 +78,7 @@ public class PostService {
             postRepository.save(post);
 
             // DTO 변환 및 반환
-            GoodnewsDto.GoodnewsResponseDto response = GoodnewsDto.GoodnewsResponseDto.from(post);
+            GoodnewsDto.GoodnewsResponseDto response = GoodnewsDto.GoodnewsResponseDto.from(post, mapToWriterDto(user.getId()));
 
             return ResponseEntity.status(SuccessStatus.POST_CREATED.getHttpStatus())
                     .body(ApiResponse.onSuccess(SuccessStatus.POST_CREATED.getMessage(), response));
@@ -90,6 +105,7 @@ public class PostService {
                 .updatedAt(post.getUpdatedAt())
                 .likeCount(postLikeRepository.countByPostId(post.getId()))
                 .commentCount(commentRepository.countByPostId(post.getId()))
+                .writer(mapToWriterDto(post.getUserId())) //작성자 추가
                 .build();
 
         // 3. ApiResponse로 감싸서 반환 (POST_DETAIL_SUCCESS 사용)
@@ -121,6 +137,7 @@ public class PostService {
                         .updatedAt(post.getUpdatedAt())
                         .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .commentCount(commentRepository.countByPostId(post.getId()))
+                        .writer(mapToWriterDto(post.getUserId()))//작성자 추가
                         .build())
                 .collect(Collectors.toList());
 
@@ -192,6 +209,7 @@ public class PostService {
                         .updatedAt(post.getUpdatedAt())
                         .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .commentCount(commentRepository.countByPostId(post.getId()))
+                        .writer(mapToWriterDto(post.getUserId()))
                         .build())
                 .collect(Collectors.toList());
 
@@ -213,7 +231,7 @@ public class PostService {
                 .map(post -> GoodnewsDto.PostDto.builder()
                         .postId(post.getId())
                         .placeId(post.getPlaceId())
-                        .placeName(post.getPlace().getPlaceName())  // 🔹 플레이스 제목 추가
+                        .placeName(post.getPlace().getPlaceName())  // 플레이스 제목 추가
                         .userId(post.getUserId())
                         .content(post.getContent())
                         .image(post.getImage())
@@ -221,6 +239,7 @@ public class PostService {
                         .updatedAt(post.getUpdatedAt())
                         .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .commentCount(commentRepository.countByPostId(post.getId()))
+                        .writer(mapToWriterDto(post.getUserId()))//작성자 추가
                         .build())
                 .collect(Collectors.toList());
 
@@ -279,6 +298,7 @@ public class PostService {
                         .updatedAt(post.getUpdatedAt())
                         .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .commentCount(commentRepository.countByPostId(post.getId()))
+                        .writer(mapToWriterDto(post.getUserId()))
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/draconist/goodluckynews/domain/member/dto/WriterInfoDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/member/dto/WriterInfoDto.java
@@ -1,0 +1,14 @@
+package com.draconist.goodluckynews.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class WriterInfoDto {
+    private Long userId;
+    private String name;           // 작성자 닉네임
+    private String profileImage;   // 프로필 이미지
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #98 

## 📝 댓글 및 대댓글 응답 개선

- `CommentResultDto`에 작성자 정보(`writer: name, profileImage`) 추가
- 모든 댓글 응답 (`getCommentsByPost`, `getMyComments`, `createComment`, `createReplyToComment`)에 `writer` 정보 포함되도록 수정
- 공통 작성자 DTO (`WriterInfoDto`) 도입
  - `userId`, `name`, `profileImage` 포함
  - `CommentService` 내부에서 `mapToWriterDto()` 함수로 변환
- 댓글 트리 구조 재귀 응답에 작성자 정보 반영
  - `toCommentResultDtoWithReplies`, `toMyCommentResultDtoWithReplies` 내부에 `.writer(...)` 추가
- 댓글 생성 / 대댓글 생성 시 응답도 DTO로 통일
  - 엔티티 그대로 반환하지 않고, `toSingleCommentDto()`를 통해 응답 포맷 통일

🔁 프론트에서 `writer.name`, `writer.profileImage`를 일관되게 사용할 수 있도록 응답 구조 정리 완료


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
