### PR TITLE
refactor : 플레이스 이미지 추가 및 주석 수정

### DIFF
--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/CommentDto.java
@@ -23,9 +23,11 @@ public class CommentDto {
         private Long postId;     // 댓글이 속한 게시글 ID
         private String content;  // 댓글 내용
         private LocalDateTime createdAt; // 작성 날짜
-        private int likeCount;   // 댓글 좋아요 개수 추가
-        private List<CommentResultDto> replies;// 답글 리스트 추가
-        private WriterInfoDto writer; // 작성자 정보 추가하기
+        private int likeCount;   // 댓글 좋아요 개수
+        private List<CommentResultDto> replies;// 답글 리스트
+        private WriterInfoDto writer; // 작성자 정보
+        private String placeImg; // 플레이스 이미지
+        private String placeName; // 플레이스 이름
 
     }
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
@@ -30,7 +30,7 @@ public class GoodnewsDto {
         private Long placeId;
         private Long userId;
         private String content;
-        private String image;
+        private String image; //게시글 이미지
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private String placeName;
@@ -61,8 +61,9 @@ public class GoodnewsDto {
         private Long placeId;      // 게시글이 속한 장소 ID
         private Long userId;       // 게시글 작성자 ID
         private String content;    // 게시글 내용
-        private String placeName;  // 🔹 플레이스 제목 추가
+        private String placeName;  // 플레이스 제목 추가
         private String image;      // 이미지 URL (선택 사항)
+        private String placeImg;   // 장소 이미지 추가
         private LocalDateTime createdAt; // 생성 날짜
         private LocalDateTime updatedAt; // 수정 날짜
         private int likeCount;     // 좋아요 개수 추가

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Comment.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Comment.java
@@ -39,4 +39,8 @@ public class Comment {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId", insertable = false, updatable = false)
+    private Post post; // 연관관계 추가하기
 }

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Post.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/entity/Post.java
@@ -22,7 +22,7 @@ public class Post {
     @Column(name = "postId")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)  // 🔹 연관관계 매핑 (지연 로딩)
+    @ManyToOne(fetch = FetchType.LAZY)  // 연관관계 매핑 (지연 로딩)
     @JoinColumn(name = "placeId", insertable = false, updatable = false)  // 🔹 placeId를 외래키로 사용
     private Place place;  // 🔹 플레이스 엔티티 참조
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
@@ -155,6 +155,10 @@ public class CommentService {
                 .map(reply -> toMyCommentResultDtoWithReplies(reply, userId))
                 .collect(Collectors.toList());
 
+        //Post, Place 접근 (플레이스 이미지 가져와야함)
+        Post post = comment.getPost();
+        Place place = post !=null? post.getPlace() : null;
+
         return CommentDto.CommentResultDto.builder()
                 .commentId(comment.getId())
                 .postId(comment.getPostId())
@@ -163,6 +167,8 @@ public class CommentService {
                 .likeCount(commentLikeRepository.countByCommentId(comment.getId()))
                 .writer(mapToWriterDto(comment.getUserId())) //작성자 정보 추가
                 .replies(replyDtoList)
+                .placeImg(place != null ? place.getPlaceImg() : null) // 플레이스 이미지 추가
+                .placeName(place != null ? place.getPlaceName() : null) // 플레이스 이름 추가
                 .build();
     }
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/PostService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/PostService.java
@@ -232,6 +232,7 @@ public class PostService {
                         .postId(post.getId())
                         .placeId(post.getPlaceId())
                         .placeName(post.getPlace().getPlaceName())  // 플레이스 제목 추가
+                        .placeImg(post.getPlace().getPlaceImg()) // 플레이스 이미지 추가
                         .userId(post.getUserId())
                         .content(post.getContent())
                         .image(post.getImage())

--- a/src/main/java/com/draconist/goodluckynews/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/place/dto/PlaceDTO.java
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlaceDTO {
-    private Long placeId;   // 🔹 placeId 추가
+    private Long placeId;   // placeId 추가
     private String placeName;
     private String placeDetails;
     private String placeImg;

--- a/src/main/java/com/draconist/goodluckynews/domain/place/entity/Place.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/place/entity/Place.java
@@ -27,7 +27,7 @@ public class Place extends BaseEntity {
     private String placeImg;
 
 
-    // ✅ 북마크 상태 저장 (true: 북마크됨, false: 북마크 안됨)
+    // 북마크 상태 저장 (true: 북마크됨, false: 북마크 안됨)
     @Column(name = "isBookmarked", nullable = false)
     private boolean isBookmarked = false;
 
@@ -37,7 +37,7 @@ public class Place extends BaseEntity {
     }
 
 
-    // ✅ 플레이스 정보 수정 메서드 추가
+    // 플레이스 정보 수정 메서드 추가
     public void updatePlace(String placeName, String placeDetails, String placeImg) {
         this.placeName = placeName;
         this.placeDetails = placeDetails;
@@ -47,7 +47,7 @@ public class Place extends BaseEntity {
     }
 
 
-    // ✅ 북마크 토글 기능 추가
+    // 북마크 토글 기능 추가
     public void toggleBookmark() {
         this.isBookmarked = !this.isBookmarked;
     }

--- a/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/ErrorStatus.java
+++ b/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/ErrorStatus.java
@@ -32,32 +32,32 @@ public enum ErrorStatus implements BaseCode {
 	TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "TOKEN4001", "토큰이 없거나 만료 되었습니다."),
 	TOKEN_NO_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "TOKEN4002", "토큰에 권한이 없습니다."),
 
-	// ✅ 게시글(희소식) 관련 오류 추가
+	// 게시글(희소식) 관련 오류 추가
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "해당하는 게시글을 찾을 수 없습니다."),
 	POST_CREATION_FAILED(HttpStatus.BAD_REQUEST, "POST4002", "게시글을 생성하는 중 오류가 발생하였습니다."),
 	POST_LIKE_FAILED(HttpStatus.BAD_REQUEST, "POST4003", "게시글 좋아요 처리 중 오류가 발생하였습니다."),
 
-	// ✅ 댓글 관련 오류 추가
+	// 댓글 관련 오류 추가
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "해당하는 댓글을 찾을 수 없습니다."),
 	COMMENT_CREATION_FAILED(HttpStatus.BAD_REQUEST, "COMMENT4002", "댓글을 생성하는 중 오류가 발생하였습니다."),
 	COMMENT_LIKE_FAILED(HttpStatus.BAD_REQUEST, "COMMENT4003", "댓글 좋아요 처리 중 오류가 발생하였습니다."),
 
 
-	// **✅ 추가된 Article 관련 오류**
+	// 추가된 Article 관련 오류
 	_CRAWLFAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ARTICLE4001", "기사 크롤링 중 오류가 발생했습니다."),
 	_ARTICLE_TITLE_MISSING(HttpStatus.BAD_REQUEST, "ARTICLE4002", "기사 제목이 누락되었습니다."),
 	_ARTICLE_CONTENT_MISSING(HttpStatus.BAD_REQUEST, "ARTICLE4003", "기사 본문이 누락되었습니다."),
 	_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4004", "해당하는 기사를 찾을 수 없습니다."),
 
-	// **✅ 추가된 Heart(좋아요) 관련 오류**
+	// 추가된 Heart(좋아요) 관련 오류
 	_ALREADY_HEARTED(HttpStatus.BAD_REQUEST, "HEART4001", "이미 좋아요를 누른 상태입니다."),
 	_HEART_NOT_FOUND(HttpStatus.NOT_FOUND, "HEART4002", "좋아요를 찾을 수 없습니다."),
 
-	// **✅ 추가된 CompletedTime(기사 완료) 관련 오류**
+	// 추가된 CompletedTime(기사 완료) 관련 오류
 	_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "ARTICLE4005", "이미 완료된 기사입니다."),
 	_COMPLETED_NOTFOUND(HttpStatus.BAD_REQUEST, "ARTICLE4002", "기사를 찾을수 없습니다"),
 
-	// **✅ 추가된 페이지네이션 관련 오류**
+	// 추가된 페이지네이션 관련 오류
 	_PAGE_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "PAGE4001", "잘못된 페이지네이션 요청입니다. 페이지 번호는 0 이상이어야 합니다."),
 	_PAGE_EMPTY_RESULT(HttpStatus.NOT_FOUND, "PAGE4002", "조회된 페이지가 없습니다. 다시 확인해주세요."),
 

--- a/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/SuccessStatus.java
+++ b/src/main/java/com/draconist/goodluckynews/global/enums/statuscode/SuccessStatus.java
@@ -20,17 +20,17 @@ public enum SuccessStatus implements BaseCode {
 	// 특정 플레이스 조회 성공 응답 추가
 	_PLACE_DETAIL_SUCCESS(HttpStatus.OK, "PLACE200", "플레이스 상세 정보 조회 성공"),
 
-	// ✅ 내가 만든 플레이스 조회 성공 응답 추가
+	// 내가 만든 플레이스 조회 성공 응답 추가
 	_PLACE_MYLIST_SUCCESS(HttpStatus.OK, "PLACE207", "내가 만든 플레이스 조회 성공"),
 
 
 	// 플레이스 수정 성공 응답 추가
 	_PLACE_UPDATED(HttpStatus.OK, "PLACE200", "플레이스 수정 성공"),
 
-	// ✅ 북마크 추가/삭제(토글) 성공 응답 추가
+	// 북마크 추가/삭제(토글) 성공 응답 추가
 	_BOOKMARK_UPDATED(HttpStatus.OK, "BOOKMARK200", "북마크 상태가 업데이트되었습니다."),
 
-	// ✅ 게시글(희소식) 관련 응답 추가
+	// 게시글(희소식) 관련 응답 추가
 	POST_CREATED(HttpStatus.CREATED, "POST201", "게시글이 성공적으로 생성되었습니다."),
 	POST_DELETED(HttpStatus.OK, "POST202", "게시글이 성공적으로 삭제되었습니다."),
 	POST_UPDATED(HttpStatus.OK, "POST203", "게시글이 성공적으로 수정되었습니다."),
@@ -38,7 +38,7 @@ public enum SuccessStatus implements BaseCode {
 	POST_LIST_SUCCESS(HttpStatus.OK, "POST205", "게시글 목록이 성공적으로 조회되었습니다."),
 	POST_DETAIL_SUCCESS(HttpStatus.OK, "POST206", "게시글 상세 정보가 성공적으로 조회되었습니다."),
 
-	// ✅ 댓글 관련 응답 추가
+	// 댓글 관련 응답 추가
 	COMMENT_CREATED(HttpStatus.CREATED, "COMMENT201", "댓글이 성공적으로 생성되었습니다."),
 	COMMENT_DELETED(HttpStatus.OK, "COMMENT202", "댓글이 성공적으로 삭제되었습니다."),
 	COMMENT_UPDATED(HttpStatus.OK, "COMMENT203", "댓글이 성공적으로 수정되었습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101 

## 📝작업 내용

>
 ### 1. `/api/posts/mypage` 응답 플레이스 이미지 추가 
희소식(게시글) 마이페이지 목록 조회 시 **장소 이미지와 장소 이름**을 함께 반환하도록 `PostDto`에 다음 필드를 추가하였습니다:

- `placeName`: 장소 이름
- `placeImg`: 장소 대표 이미지 (TEXT URL)

### 2. `/api/comments/mypage` 응답 플레이스 이미지, 이름 추가 
내가 작성한 **댓글 및 대댓글 조회 시**, 해당 게시글의 **장소 정보(`placeName`, `placeImg`)도 함께 포함**되도록 `CommentResultDto` 구조를 확장하였습니다:

- `placeName`: 장소 이름
- `placeImg`: 장소 이미지 URL

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
