### PR TITLE
refactor : 좋아요 북마크 로직 수정

### DIFF
--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/controller/PostController.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/controller/PostController.java
@@ -28,17 +28,23 @@ public class PostController {
     }//희소식 생성
 
     @GetMapping("/{postId}")
-    public ResponseEntity<?> getPostById(@PathVariable Long postId) {
-        return postService.getPostById(postId);
-    }//희소식 상세 조회
+    public ResponseEntity<?> getPostById(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal String email
+    ) {
+        return postService.getPostById(postId, email);
+    }
+//희소식 상세 조회
 
     @GetMapping
     public ResponseEntity<?> getAllPosts(
-            @RequestParam(defaultValue = "0") int page,  // 기본값 0
-            @RequestParam(defaultValue = "10") int size // 기본값 10
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal String email // 로그인 사용자 email 주입
     ) {
-        return postService.getAllPosts(page, size);
-    }//희소식 전체 조회 (페이지네이션)
+        return postService.getAllPosts(page, size, email);
+    }
+//희소식 전체 조회 (페이지네이션)
 
     @PostMapping("/{postId}/like")
     public ResponseEntity<?> togglePostLike(

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/dto/GoodnewsDto.java
@@ -34,6 +34,7 @@ public class GoodnewsDto {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private String placeName;
+
         private WriterInfoDto writer; //작성자 정보 추가
 
         public static GoodnewsResponseDto from(Post post, WriterInfoDto writer) {
@@ -69,6 +70,7 @@ public class GoodnewsDto {
         private int likeCount;     // 좋아요 개수 추가
         private int commentCount;  // 댓글 개수 추가
         private WriterInfoDto writer;// 작성자 정보 필드 추가
+        private boolean liked; // 좋아요 여부
 
     }//값 반환 dto
 

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/repository/PostLikeRepository.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/repository/PostLikeRepository.java
@@ -6,7 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
     Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
+
+    boolean existsByUserIdAndPostId(Long userId, Long postId); // ✅ 추가
+
     int countByPostId(Long postId);   // 특정 게시글의 좋아요 개수 조회
+
     void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/goodNews/service/CommentService.java
@@ -128,7 +128,6 @@ public class CommentService {
     }
 
 
-
     //사용자의 댓글 조회
     public ResponseEntity<?> getMyComments(String email) {
         Member member = memberRepository.findMemberByEmail(email)

--- a/src/main/java/com/draconist/goodluckynews/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/place/controller/PlaceController.java
@@ -43,8 +43,11 @@ public class PlaceController {
 
 
     @GetMapping("/{placeId}")
-    public ResponseEntity<?> getPlaceById(@PathVariable Long placeId) {
-        return placeService.getPlaceById(placeId);
+    public ResponseEntity<?> getPlaceDetail(
+            @PathVariable Long id,
+            @AuthenticationPrincipal String email // JWT 인증 객체 등으로부터 유저 식별
+    ) {
+        return placeService.getPlaceById(id, email);
     }//특정 플레이스 상세 조회
 
     @PatchMapping("/{placeId}")

--- a/src/main/java/com/draconist/goodluckynews/domain/place/service/PlaceService.java
+++ b/src/main/java/com/draconist/goodluckynews/domain/place/service/PlaceService.java
@@ -147,27 +147,35 @@ public class PlaceService {
     }
     //플레이스 전체 조회 ( 페이지네이션 )
 
-    public ResponseEntity<?> getPlaceById(Long placeId) {
+    public ResponseEntity<?> getPlaceById(Long placeId, String email) {
         //  0. placeId 유효성 검사
         if (placeId == null || placeId <= 0) {
             throw new GeneralException(ErrorStatus.INVALID_PLACE_ID);
         }
 
+        // 1. 회원 조회
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 1. placeId로 Place 조회 (없으면 예외 발생)
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PLACE_NOT_FOUND));
 
-        // 2. DTO로 변환
+        // 2. 좋아요 수 및 여부 확인
+        int likeCount = placeLikeRepository.countByPlaceId(place.getId());
+        boolean isBookmarked = placeLikeRepository.existsByPlaceIdAndUserId(place.getId(), member.getId());
+
+        // 3. DTO로 변환
         PlaceDTO placeDTO = PlaceDTO.builder()
-                .placeId(place.getId())  // 🔹 placeId 추가
+                .placeId(place.getId())  // placeId 추가
                 .placeName(place.getPlaceName())
                 .placeDetails(place.getPlaceDetails())
                 .placeImg(place.getPlaceImg())
+                .likeCount(likeCount)
+                .isBookmark(isBookmarked)
                 .build();
 
-
-        // 3. 성공 응답 반환
+        // 4. 성공 응답 반환
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus._PLACE_DETAIL_SUCCESS.getMessage(),
                 placeDTO


### PR DESCRIPTION
## 📝작업 내용

> 
기능 추가 
- **희소식 전체 조회 응답에 `liked` 여부 추가**
- **상세 조회 응답에도 `liked` 필드 반영**
- **로그인 사용자 기준으로 좋아요 여부 판단하여 반환**

코드 수정 
- `PostDto`에 `boolean liked` 필드 추가  
- `postService.getAllPosts()` 수정 → 사용자 email을 통해 좋아요 여부 확인 후 DTO에 반영
- `postService.getPostById()`도 동일하게 `liked` 정보 포함
- 기존 `likeCount`는 그대로 유지하며, 사용자 맞춤 `liked` 필드만 추가됨

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
